### PR TITLE
chore: fix OSPO compliance issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,33 @@
+# How to contribute
+
 THIS PROJECT DOES NOT ACCEPT PATCHES OR CONTRIBUTIONS.
 
-Please contribute to our other projects like [looker-open-source/sdk-codegen](https://github.com/looker-open-source/sdk-codegen). 
+## Before you begin
 
-This project follows [Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+### Sign our Contributor License Agreement
+
+Contributions to this project must be accompanied by a
+[Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
+You (or your employer) retain the copyright to your contribution; this simply
+gives us permission to use and redistribute your contributions as part of the
+project.
+
+If you or your current employer have already signed the Google CLA (even if it
+was for a different project), you probably don't need to do it again.
+
+Visit <https://cla.developers.google.com/> to see your current agreements or to
+sign a new one.
+
+### Review our community guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+
+## Contribution process
+
+### Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,4 @@
-"MIT License
+© 2021 Google LLC.  All rights reserved.
 
-Copyright (c) 2025 Google
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions.
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE."
+This software is subject to the Google Cloud Terms of Service, as
+modified by the "General Software Terms" of the Google Cloud Service Specific Terms, available at: https://cloud.google.com/terms/service-terms.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ReadMe for LookML Developers
 
+This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).
 
 ## About this LookML Block
 
@@ -17,10 +18,7 @@ This Block gives business users the ability to make predictions (categorical or 
 
 Models created by AutoML Tables can take hours to run; therefore, users should set up the required parameters for defining the model (name, target, features, etc...) and then use SEND (rather than RUN) to create the model asynchronously via Looker Scheduler. When the model is complete, the user will receive an email and can return to the explore to review the results. Note any user of these AutoML explores will need `schedule_look_emails` permission (see [Content Delivery Permissions](https://docs.looker.com/sharing-and-publishing/scheduling-and-sharing/scheduling-for-admins)).
 
----
 > <b><font size = "3" color="#174EA6"> <i class='fa fa-info-circle'></i>  Reach out to your Looker account team if you would like to partner with Looker Professional Services to implement this Looker + BQML block or customize for your specific use case</font></b>
-
----
 
 ## Block Requirements
 ### 1. An existing [BigQuery database connection](https://docs.looker.com/setup-and-management/database-config/google-bigquery#overview):
@@ -35,14 +33,9 @@ Models created by AutoML Tables can take hours to run; therefore, users should s
 
 During installation you will be asked for the connection and dataset name. These values will be added as constants to the Block's project marketplace_lock file. These constants will be referenced throughout the Block as AUTO ML models are created.
 
----
  <font size = "3"><font color = "red"> <i class='fa fa-exclamation-triangle'></i><b> note:  BigQuery ML processes and stages data in the same location.</b></font></font><br> See [BigQuery ML Locations](https://cloud.google.com/bigquery-ml/docs/locations) for more details. The example Explore included in this Block is based on BigQuery public dataset stored in the `US` multi-region location. Therefore, to use the Block’s example Explore you should name a dataset also located in the `US` multi-region. To use this Block with data stored in region or multi-region outside of the `US`, name an AutoML model dataset located in the same region or multi-region and use refinements to hide the example Explore as it will not work in regions outside of the `US`.
 
-
  <font size = "3"><font color="red"><i class='fa fa-exclamation-triangle'></i><b> note: This Block is intended to be used with only one data connection and one dataset for model processing.</b></font></font><br>If you would like to use Block with multiple data connections, customization of the Block is required. Reach out to your Looker account team for more information and guidance from Looker Professional Services.
-
----
-
 
 ## Installation Steps
 1. From the Looker Marketplace page for [BigQuery ML Classification and Regression (AutoML Tables) block](/marketplace/view/bqml-automl), click `INSTALL` button
@@ -60,10 +53,7 @@ Upon successful completion of the installation, a green Check Mark and bar will 
 | explore | AutoML Tables: Census Income Predictions | found in Explore menu under Looker + BigQuery ML |
 | explore | AutoML Tables: Model Info  | found in Explore menu under Looker + BigQuery ML; captures details for each AutoML model created with this Block |
 
----
  <font size = "3"><font color="red"><i class='fa fa-exclamation-triangle'></i><b> note:  The marketplace_bqml-automl project is installed as a bare GIT repository.</b></font></font><br>For version control utilizing a remote repository, you will need to [update the connection settings for your Git repository](https://docs.looker.com/data-modeling/getting-started/setting-up-git-connection).
-
----
 
 At this point you can begin creating your own Explores incorporating the AutoML model workflow (see next section for details on building your own Explores) or navigate to the included explore example and create a classification or regression model.
 
@@ -89,11 +79,7 @@ At a high-level the steps for each use case are:
 
 Details and code examples for each step are provided next. Note, all steps take place in `marketplace_bqml-automl` project while in **development mode**.
 
----
  <font size = "3"><font color="red"><i class='fa fa-exclamation-triangle'></i><b> note:  If copying/pasting example LookML from this document, ensure quotation marks are straight quotes (") </b></font></font><br>When pasting from this document, quotations may appear as curly or smart quotes (“). If necessary, re-type quotes in the LookML IDE to change to straight quotes.
-
----
-
 
 ### 1. Create Folder for all Use Case files (one folder per use case)
 When you open the `marketplace_bqml-automl` project while in development mode and review the `File Browser` pane, you will see the project contains a folder called `imported_projects`. Expanding this folder you will see a subfolder named `bqml-automl`. This folder contains all the models, explores and views for the Block. These files are read-only; however, we will be including these files in the use case model and refining/extending a select few files to support the use case. You should keep all files related to the use case in a single folder. Doing so will allow easy editing of a use case. Within the project, you should create a separate folder for each use case.
@@ -121,10 +107,8 @@ Add a new model file for the use case, update the connection, and add include st
 | Add an include statement for the Block's `automl_tables.explore` so the file is available to this use case model and can be extended into the new Explore created in the next step.| include: "//bqml-automl/**/automl_tables.explore" |
 | Click `SAVE` | |
 
-
 ### 3. Make Refinements of select Explores and Views from the Block
 Just like we used the automl_tables explore as a building block for the use case explore, we will adapt the Block's `input_data.view`, `model_name_suggestions.explore` and `automl_predict.view` for the use case using LookML refinements syntax. To create a refinement you add a plus sign (+) in front of the name to indicate that it's a refinement of an existing view. All the parameters of the existing view will be used and select parameters can be modified (i.e., overwrite the original value). For detailed explanation of refinements, refer to the [LookML refinements](https://docs.looker.com/data-modeling/learning-lookml/refinements) documentation page. Within the use case folder, add a new `input_data.view`, a new `model_name_suggestions.explore` and a new `automl_predict.view`. Keep reading for detailed steps for each refinement file.
-
 
 #### <font size=5>3a. input_data.view </font><font color='red'> (REQUIRED)
 
@@ -150,10 +134,7 @@ The input_data.view is where you define the data to use as input into the model.
 | Review the remaining LookML and edit as necessary with:<br>a. names, labels, group labels, descriptions<br>b. identify the primary key field<br>c. Modify date formats as necessary. For example, dates are automatically defined as a `dimension_group with type of time` so modify as necessary for timeframes or convert to a single date dimension.<d> Add any additional measures if needed (only count created by default) | dimension: ga_session_id {<br>  type: string<br>  primary_key: yes<br>  sql: <br>${TABLE}.ga_session_id ;;<br>} |
 | Click `SAVE` | |
 
----
    <font size = "3"><font color="red"><i class='fa fa-exclamation-triangle'></i><b> note: Avoid using BigQuery analytic functions such as ROW_NUMBER() OVER() in the SQL definition of a use case's input data.</b></font></font> Including analytic functions may cause BigQuery to return an `InternalError` code when used with BigQuery ML functions. If your input data is missing a primary key, CONCAT(*field_1, field_2, ...*) two or more columns to generate a unique ID instead of using ROW_NUMBER() OVER().
-
----
 
 #### <font size=5>3b. model_name_suggestions.explore </font><font color='red'> (REQUIRED)
 To create an AutoML model, the user must enter a name for the model and can type in any string value. The AutoML Explore also allows the user to evaluate a model which has already been created. The `Model Name` parameter allows users to select the name from a list of existing models created by the given Explore. These suggested values come from the `AUTOML_TABLES_MODEL_INFO` table stored in the Model Details dataset defined for the Block during installation. Because this table captures details for all models created with the Block across all Explores, we need to filter the suggestions by Explore name–the Explore which will be created in `Implementation Step 4`. If you do not filter for the use case Explore, an error would occur if the user tries to evaluate a model based on different input data.
@@ -170,7 +151,6 @@ The name suggestions come from the `model_name_suggestions.explore` and in this 
 | On line 1 of the blank file, insert include statement for the Block explore to be refined | include: "//bqml-automl/**/model_name_suggestions.explore" |
 | On the next lines, enter<br> a. the explore name using the + refinement syntax<br> b. update sql_always_where syntax with use case explore name (as shown in <font color = 'orange'>bold</font> in the example) | explore: +model_name_suggestions {<br>  sql_always_where: ${model_info.explore} =<font color='orange'><b>'ga_repeat_visitor'</b></font>;;<br>} |
 
-
 #### <font size=5>3c. automl_predict.view </font><font color='red'> (REQUIRED)
 When generating the prediction for the input dataset, the resulting output includes the primary key of the dataset. For example, you may be generating a prediction for a customer or a session or other types of observations. Because the field name in the prediction output file can take on any value, a generic name is used instead. `input_data_primary_key`. To handle this you need to create a refinement of the automl_predict.view and specify the the *label:* and *sql:* parameters for the `input_data_primary_key` dimension. The *label:* and *sql:* parameters should match the primary key column from `input_data.view`. Note the label could be changed to reflect a more meaningful label the user will recognize.
 
@@ -186,7 +166,6 @@ When generating the prediction for the input dataset, the resulting output inclu
 | On next lines, add dimension: input_data_primary_key and update the *label:* and *sql:* parameters accordingly:| dimension: input_data_primary_key {<br>    <font color='orange'><b>label: "GA Session ID"<br>    sql: ${TABLE}.ga_session_id;; </b></font><br>} |
 | Click `SAVE`| |
 
-
 ### 4. Add New Explore which Extends the Block's AutoML Tables Explore
 As noted earlier, all the files related to this Block are found in the `imported_projects\bqml-automl` directory. The Explore file `automl_tables.explore` specifies all the views and join relationships to generate the stepped workflow the user will navigate through to create and evaluate classification and/or regression models using AutoML. For each use case, you will use the `automl_tables` Explore as a starting point by extending it into a new Explore. The new Explore will build upon the content and settings from the original Explore and modify some of the components to fit the use case. See the [extends for Explores](https://docs.looker.com/reference/explore-params/extends) documentation page for more information on extends. In the previous step, we added the `include: "//bqml-automl/**/automl_tables.explore"` statement to the model file so that we could use this Explore for the use case. Below are the steps for adding a new Explore to the use case model file.
 
@@ -196,12 +175,7 @@ As noted earlier, all the files related to this Block are found in the `imported
 | Add Explore LookML which <br> a. includes label, group_label and/or description relevant to your use case<br>b. extends the automl_tables explore<br>c. updates the join parameter between `automl_predict` and `input_data` to reflect correct unit<br> <br>The AutoML model output generates a forecast for the target variable modeled and is named __input_data_primary_key__. <br>The target variable modeled could vary by use case (e.g., visitor, customer, machine), so need to update the Explore to capture the correct unit defined in the use case's `input_data` view file (as defined in the previous step).<br><br>In the example, edit the terms in <b><font color='orange'>bold</font></b> to fit your use case.<br> |explore: <font color='orange'><b>ga_repeat_visitor</b></font> {<br>  label: <font color='orange'><b>"AutoML: Google Analytics Repeat Visitor"</b></font><br>  description: <font color='orange'><b>"Use this Explore to create Classification or Regression models to make categorical or numerical predictions for Google Analytics data"</b></font><br><br>  extends: [automl_tables] <br><br>   join: automl_predict {<br>    type:full_outer<br>    relationship: one_to_one<br>    sql_on: <font color = 'orange'><b>${input_data.ga_session_id}</b></font> = ${automl_predict.input_data_primary_key} ;;<br>  }<br>} |
 | Click `SAVE`| |
 
-
----
    <font size = "3"><font color="red"><i class='fa fa-exclamation-triangle'></i><b> note: When creating the AutoML model asynchronously, use production mode </b></font></font> As noted earlier, due to the lengthy processing times common with AutoML Tables, users should set the model parameters and SEND the model creation query via Looker Scheduler rather than choosing RUN. Explores can be sent as one-time deliveries only and reflect the production mode of LookML (not development mode). Therefore, when testing LookML changes for this project you should commit and push to production and exit development mode.
-
----
-
 
 ## AutoML Tables CREATE MODEL Syntax
 
@@ -221,13 +195,10 @@ Note the parameter `select features` allows the user to identify the columns to 
 > <b><font size = "3" color="#174EA6"> <i class='fa fa-info-circle'></i> Note, AutoML Explores can be customized to include other model types, options and parameters. </font></b> If you would like to use a different machine learning model type or include other model parameters like modeling optimization objective, training/validation sets, or target probability thresholds, contact your Looker account team for guidance.
 >
 
-
-
 ## Enabling Business Users
 
 This block comes with a [Quick Start Guide for Business Users](https://github.com/looker/block-bqml-automl/blob/master/QUICK_START_GUIDE.md) and the following example Explore for enabling business users.
 - AutoML Tables: Census Income Prediction
-
 
 ## Resources
 
@@ -239,9 +210,7 @@ This block comes with a [Quick Start Guide for Business Users](https://github.co
 
 [BigQuery ML Locations](https://cloud.google.com/bigquery-ml/docs/locations)
 
-
 ### Find an error or have suggestions for improvements?
 Blocks were designed for continuous improvement through the help of the entire Looker community, and we'd love your input. To log an error or improvement recommendations, simply create a "New Issue" in the corresponding Github repo for this Block. Please be as detailed as possible in your explanation, and we'll address it as quickly as we can.
-
 
 #### Author: Google


### PR DESCRIPTION
This automated PR addresses OSPO compliance requirements for the `bqml-automl` block repository.

Changes included:
- Appended standard Google Open Source disclaimer to `README.md`.
- Replaced any legacy or incorrect license file with the standardized `LICENSE` file (containing verbatim Google Cloud Terms of Service) matching the repository's creation year from git history.
- Added the standardized `CONTRIBUTING.md` file with CLA links.